### PR TITLE
Improve fourSum function with unique quadruplets

### DIFF
--- a/3Sum and 4Sum/4Sum.playground/Contents.swift
+++ b/3Sum and 4Sum/4Sum.playground/Contents.swift
@@ -3,19 +3,7 @@
 print("Hello, Swift 4.2!")
 #endif
 
-extension Collection where Element: Equatable {
-  
-  /// In a sorted collection, replaces the given index with a successor mapping to a unique element.
-  ///
-  /// - Parameter index: A valid index of the collection. `index` must be less than `endIndex`
-  func formUniqueIndex(after index: inout Index) {
-    var prev = index
-    repeat {
-      prev = index
-      formIndex(after: &index)
-    } while index < endIndex && self[prev] == self[index]
-  }
-}
+
 
 extension BidirectionalCollection where Element: Equatable {
   
@@ -32,33 +20,49 @@ extension BidirectionalCollection where Element: Equatable {
 }
 
 func fourSum<T: BidirectionalCollection>(_ collection: T, target: T.Element) -> [[T.Element]] where T.Element: Numeric & Comparable {
-  let sorted = collection.sorted()
-  var ret: [[T.Element]] = []
+    let sorted = collection.sorted()
+    var ret: [[T.Element]] = []
   
-  var l = sorted.startIndex
-  FourSum: while l < sorted.endIndex { defer { sorted.formUniqueIndex(after: &l) }
-    var ml = sorted.index(after: l)
-                                      
-    ThreeSum: while ml < sorted.endIndex { defer { sorted.formUniqueIndex(after: &ml) }
-      var mr = sorted.index(after: ml)
-      var r = sorted.index(before: sorted.endIndex)
-      
-      TwoSum: while mr < r && r < sorted.endIndex {
-        let sum = sorted[l] + sorted[ml] + sorted[mr] + sorted[r]
-        if sum == target {
-          ret.append([sorted[l], sorted[ml], sorted[mr], sorted[r]])
-          sorted.formUniqueIndex(after: &mr)
-          sorted.formUniqueIndex(before: &r)
-        } else if sum < target {
-          sorted.formUniqueIndex(after: &mr)
-        } else {
-          sorted.formUniqueIndex(before: &r)
+    var l = sorted.startIndex
+    FourSum: while l < sorted.endIndex {
+        // Skip over any repeated elements
+        while l < sorted.endIndex - 1, sorted[l] == sorted[sorted.index(after: l)] {
+            sorted.formIndex(after: &l)
         }
-      }
+        defer { sorted.formIndex(after: &l) }
+        var ml = sorted.index(after: l)
+                                      
+        ThreeSum: while ml < sorted.endIndex {
+            // Skip over any repeated elements
+            while ml < sorted.endIndex - 1, sorted[ml] == sorted[sorted.index(after: ml)] {
+                sorted.formIndex(after: &ml)
+            }
+            defer { sorted.formIndex(after: &ml) }
+            var mr = sorted.index(after: ml)
+            var r = sorted.index(before: sorted.endIndex)
+      
+            TwoSum: while mr < r && r < sorted.endIndex {
+                let sum = sorted[l] + sorted[ml] + sorted[mr] + sorted[r]
+                if sum == target {
+                    ret.append([sorted[l], sorted[ml], sorted[mr], sorted[r]])
+                    // Skip over any repeated elements
+                    while mr < r, sorted[mr] == sorted[sorted.index(after: mr)] {
+                        sorted.formIndex(after: &mr)
+                    }
+                    while mr < r, sorted[r] == sorted[sorted.index(before: r)] {
+                        sorted.formIndex(before: &r)
+                    }
+                } else if sum < target {
+                    sorted.formIndex(after: &mr)
+                } else {
+                    sorted.formIndex(before: &r)
+                }
+            }
+        }
     }
-  }
-  return ret
+    return ret
 }
+
 
 // answer: [[-2, -1, 1, 2], [-2, 0, 0, 2], [-1, 0, 0, 1]]
 fourSum([1, 0, -1, 0, -2, 2], target: 0)


### PR DESCRIPTION
This commit improves the fourSum function by removing duplicates and returning only unique quadruplets that add up to the specific target. The code now also skips over any repeated elements in the input collection, making it more efficient and accurate. The unnecessary formUniqueIndex function is removed which is not needed in this version of the code, and minor changes are made to the existing code to improve readability and maintainability.

<!-- Thanks for contributing to the SAC! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist

- [x] I've looked at the [contribution guidelines](https://github.com/raywenderlich/swift-algorithm-club/blob/master/.github/CONTRIBUTING.md).
- [x] This pull request is complete and ready for review.

### Description

<!-- In a short paragraph, describe the PR --> 

